### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 
 name: 'Quozen CI'
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/qozara/Quozen/security/code-scanning/4](https://github.com/qozara/Quozen/security/code-scanning/4)

In general, the fix is to explicitly declare `permissions` for the workflow (or per job) so that the `GITHUB_TOKEN` has only the minimum required scopes. Since these jobs only check out code, install dependencies, run tests, and upload artifacts, they need only read access to repository contents; no write permission appears necessary.

The best minimal fix without changing functionality is to add a top‑level `permissions` block just under the workflow `name:` (or above `on:`) in `.github/workflows/ci.yml`, setting `contents: read`. This will apply to all jobs, including `test-e2e`, and satisfies CodeQL’s recommendation while keeping behavior unchanged, because all current steps work fine with read‑only repository access. No job‑specific overrides are needed, and no additional keys (like `pull-requests: write`) are required given the existing steps.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a new block:
  ```yaml
  permissions:
    contents: read
  ```
  between the existing `name: 'Quozen CI'` and `on:` lines (around lines 3–5).
- No imports or additional methods are necessary; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
