### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/ai-proxy/tests/kms.test.ts
+++ b/apps/ai-proxy/tests/kms.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { encrypt, decrypt } from '../src/lib/kms';
 import { webcrypto } from 'node:crypto';
 


### PR DESCRIPTION
To fix the problem, remove the unused `beforeEach` named import from the `vitest` import statement. This preserves all existing functionality because the test suite does not call `beforeEach` anywhere, and the rest of the imports remain intact.

Concretely:
- In `apps/ai-proxy/tests/kms.test.ts`, edit the first line so it reads `import { describe, it, expect } from 'vitest';` (i.e., delete `beforeEach` and the trailing comma/space around it).
- No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._