### PR TITLE
Robust User ID Migration (Email to Google Account ID)

### DIFF
--- a/packages/core/src/finance/LedgerService.ts
+++ b/packages/core/src/finance/LedgerService.ts
@@ -128,6 +128,24 @@ export class LedgerService {
         const settlements = await this.repo.getSettlements();
         const members = await this.repo.getMembers();
 
+        const currentUserMember = members.find(m => m.email === this.user.email || m.userId === this.user.id);
+        if (currentUserMember && currentUserMember.userId !== this.user.id) {
+            await this.repo.migrateUser(currentUserMember.userId, this.user.id, this.user.name);
+            
+            // Apply migration to the loaded in-memory data
+            expenses.forEach(e => {
+                if (e.paidByUserId === currentUserMember.userId) e.paidByUserId = this.user.id;
+                e.splits?.forEach(s => {
+                    if (s.userId === currentUserMember.userId) s.userId = this.user.id;
+                });
+            });
+            settlements.forEach(s => {
+                if (s.fromUserId === currentUserMember.userId) s.fromUserId = this.user.id;
+                if (s.toUserId === currentUserMember.userId) s.toUserId = this.user.id;
+            });
+            currentUserMember.userId = this.user.id;
+        }
+
         return new Ledger({ expenses, settlements, members });
     }
 }

--- a/packages/core/src/infrastructure/GroupRepository.ts
+++ b/packages/core/src/infrastructure/GroupRepository.ts
@@ -179,6 +179,11 @@ export class GroupRepository {
         if (validation.members) {
             const member = validation.members.find(m => m.email === this.user.email || m.userId === this.user.id);
             if (member?.role === "owner") role = "owner";
+            
+            if (member && member.userId !== this.user.id) {
+                const ledgerRepo = new LedgerRepository(this.storage, spreadsheetId);
+                await ledgerRepo.migrateUser(member.userId, this.user.id, this.user.name);
+            }
         }
 
         const settings = await this.getSettings();
@@ -227,9 +232,6 @@ export class GroupRepository {
             };
             const row = SheetDataMapper.mapFromMember(newMember);
             await this.storage.appendValues(spreadsheetId, "Members!A1", [row]);
-        } else if (existingMember.userId !== this.user.id) {
-            const ledgerRepo = new LedgerRepository(this.storage, spreadsheetId);
-            await ledgerRepo.migrateUser(existingMember.userId, this.user.id, this.user.name);
         }
 
         return await this.importGroup(spreadsheetId);

--- a/packages/core/src/infrastructure/GroupRepository.ts
+++ b/packages/core/src/infrastructure/GroupRepository.ts
@@ -227,6 +227,9 @@ export class GroupRepository {
             };
             const row = SheetDataMapper.mapFromMember(newMember);
             await this.storage.appendValues(spreadsheetId, "Members!A1", [row]);
+        } else if (existingMember.userId !== this.user.id) {
+            const ledgerRepo = new LedgerRepository(this.storage, spreadsheetId);
+            await ledgerRepo.migrateUser(existingMember.userId, this.user.id, this.user.name);
         }
 
         return await this.importGroup(spreadsheetId);

--- a/packages/core/src/infrastructure/LedgerRepository.ts
+++ b/packages/core/src/infrastructure/LedgerRepository.ts
@@ -147,4 +147,60 @@ export class LedgerRepository {
         ]);
         await this.touchGroup();
     }
+
+    async migrateUser(oldUserId: string, newUserId: string, newName?: string): Promise<void> {
+        // 1. Members
+        const members = await this.getMembers();
+        const member = members.find(m => m.userId === oldUserId);
+        if (member) {
+            member.userId = newUserId;
+            if (newName) member.name = newName;
+            
+            const rowIndex = this.memberRowMap.get(oldUserId);
+            if (rowIndex) {
+                const row = SheetDataMapper.mapFromMember(member);
+                await this.storage.updateValues(this.groupId, `Members!A${rowIndex}:Z${rowIndex}`, [row]);
+                this.memberRowMap.delete(oldUserId);
+                this.memberRowMap.set(newUserId, rowIndex);
+            }
+        }
+
+        // 2. Expenses
+        const expenses = await this.getExpenses();
+        for (const expense of expenses) {
+            let changed = false;
+            if (expense.paidByUserId === oldUserId) {
+                expense.paidByUserId = newUserId;
+                changed = true;
+            }
+            if (expense.splits) {
+                for (const split of expense.splits) {
+                    if (split.userId === oldUserId) {
+                        split.userId = newUserId;
+                        changed = true;
+                    }
+                }
+            }
+            if (changed) {
+                await this.updateExpense(expense);
+            }
+        }
+
+        // 3. Settlements
+        const settlements = await this.getSettlements();
+        for (const settlement of settlements) {
+            let changed = false;
+            if (settlement.fromUserId === oldUserId) {
+                settlement.fromUserId = newUserId;
+                changed = true;
+            }
+            if (settlement.toUserId === oldUserId) {
+                settlement.toUserId = newUserId;
+                changed = true;
+            }
+            if (changed) {
+                await this.updateSettlement(settlement);
+            }
+        }
+    }
 }

--- a/packages/core/tests/storage/logic.test.ts
+++ b/packages/core/tests/storage/logic.test.ts
@@ -88,4 +88,43 @@ describe('Storage Logic & Data Integrity', () => {
         expect((expenses[0] as any).paidByUserId || (expenses[0] as any).paidBy).toBe(invitedUserGoogleId);
         expect(expenses[0].splits.find(s => s.userId === invitedUserGoogleId)).toBeDefined();
     });
+    it('JIT Migration: User ID migration on LedgerService.getLedger (reconcileGroups workflow)', async () => {
+        // 1. Owner creates group and invites user by email
+        const group = await client.groups.create("Test Group 2", [{ email: invitedEmail }]);
+        const ledger = client.ledger(group.id);
+
+        // 2. Add an expense paid by the invited user
+        await ledger.addExpense({
+            date: '2023-10-27',
+            description: 'Lunch',
+            amount: 50,
+            paidByUserId: invitedEmail, 
+            category: 'Food',
+            splits: [{ userId: ownerUser.id, amount: 25 }, { userId: invitedEmail, amount: 25 }]
+        } as any);
+
+        // 3. User accesses the group via UI (which initializes QuozenClient and calls getLedger)
+        const invitedClient = new QuozenClient({ 
+            storage: (client as any).storage, 
+            user: { id: invitedUserGoogleId, email: invitedEmail, name: 'Invited', username: 'invited' } 
+        });
+        
+        // This simulates opening the group in the UI (triggers JIT migration)
+        const invitedLedger = await invitedClient.ledger(group.id).getLedger();
+
+        // 4. Verify that the in-memory ledger data was migrated
+        const invitedMember = invitedLedger.members.find((m: Member) => m.email === invitedEmail);
+        expect(invitedMember).toBeDefined();
+        expect(invitedMember?.userId).toBe(invitedUserGoogleId);
+
+        expect(invitedLedger.expenses.length).toBe(1);
+        expect(invitedLedger.expenses[0].paidByUserId).toBe(invitedUserGoogleId);
+        expect(invitedLedger.expenses[0].splits.find(s => s.userId === invitedUserGoogleId)).toBeDefined();
+
+        // 5. Verify that the storage was actually updated (by loading a fresh ledger as the owner)
+        const ownerLedger = await client.ledger(group.id).getLedger();
+        const storedMember = ownerLedger.members.find((m: Member) => m.email === invitedEmail);
+        expect(storedMember?.userId).toBe(invitedUserGoogleId);
+        expect(ownerLedger.expenses[0].paidByUserId).toBe(invitedUserGoogleId);
+    });
 });

--- a/packages/core/tests/storage/logic.test.ts
+++ b/packages/core/tests/storage/logic.test.ts
@@ -48,7 +48,44 @@ describe('Storage Logic & Data Integrity', () => {
         const members = await ledger.getMembers();
         const owner = members.find((m: Member) => m.userId === ownerUser.id);
 
-        // We now expect "owner", not "admin"
         expect(owner?.role).toBe("owner");
+    });
+
+    it('Failing test: User ID migration from email to Google ID on joinGroup', async () => {
+        // 1. Owner creates group and invites user by email
+        const group = await client.groups.create("Test Group", [{ email: invitedEmail }]);
+        const ledger = client.ledger(group.id);
+
+        // 2. Add an expense paid by the invited user (their ID is currently their email)
+        await ledger.addExpense({
+            date: '2023-10-27',
+            description: 'Dinner',
+            amount: 100,
+            paidByUserId: invitedEmail, // they were added by email, so their userId is the email
+            category: 'Food',
+            splits: [{ userId: ownerUser.id, amount: 50 }, { userId: invitedEmail, amount: 50 }]
+        } as any);
+
+        // 3. Invited user joins the group via magic link
+        const invitedClient = new QuozenClient({ 
+            storage: (client as any).storage, 
+            user: { id: invitedUserGoogleId, email: invitedEmail, name: 'Invited', username: 'invited' } 
+        });
+        await invitedClient.groups.joinGroup(group.id);
+
+        // 4. Verify that the invited user's ID was migrated in the members list
+        const updatedMembers = await ledger.getMembers();
+        const invitedMember = updatedMembers.find((m: Member) => m.email === invitedEmail);
+        
+        expect(invitedMember).toBeDefined();
+        // The userId should have been migrated to the new Google ID
+        expect(invitedMember?.userId).toBe(invitedUserGoogleId);
+
+        // 5. Verify that the expense was also migrated
+        const expenses = await ledger.getExpenses();
+        console.log("EXPENSES AFTER JOIN:", JSON.stringify(expenses, null, 2));
+        expect(expenses.length).toBe(1);
+        expect((expenses[0] as any).paidByUserId || (expenses[0] as any).paidBy).toBe(invitedUserGoogleId);
+        expect(expenses[0].splits.find(s => s.userId === invitedUserGoogleId)).toBeDefined();
     });
 });


### PR DESCRIPTION
## Description
This PR fixes a bug where users who were invited to a group via their email address did not have their `userId` updated to their authenticated Google Account ID upon joining. This led to issues where expenses associated with the user's email were not properly linked to their Google Account after they joined the group, causing the UI to treat them as separate users.

## Root Cause
When a user is added to a group before they have an account, they are registered with their email address as a placeholder `userId` across the `Members`, `Expenses`, and `Settlements` sheets. During the group join process, the system successfully recognized the user by their email but failed to migrate the placeholder email ID to their permanent Google Account ID in the ledger data. 

## Solution Implemented
To ensure this is handled robustly across all entry points without code duplication, the migration logic has been centralized:

1. **JIT Migration in `LedgerService.getLedger()`**
   - Added a "Just-In-Time" migration check when the ledger is accessed.
   - If a user opens a group from their dashboard (e.g., discovered via background `reconcileGroups`), their `userId` is instantly migrated. 
   - The migration is applied simultaneously to the Google Sheets backend and the loaded in-memory `Ledger` data to guarantee the UI updates smoothly without race conditions.
2. **`GroupRepository.importGroup()`**
   - Centralized the migration hook into the import logic. This seamlessly covers users joining via **Magic Links** as well as users explicitly selecting **"Import Group from Drive"**.
3. Cleaned up redundant logic from `GroupRepository.joinGroup`.

## Workflows Covered
✅ Joining a group via a Magic Link.
✅ Manually importing a group from Google Drive.
✅ Accessing a group discovered automatically via `reconcileGroups` (Google Drive share cache).

## Testing
- Extended `logic.test.ts` to simulate the full sequential workflows.
- Added `JIT Migration: User ID migration on LedgerService.getLedger (reconcileGroups workflow)` integration test.
- Verified all core integration tests pass and backwards compatibility is maintained for legacy expenses.